### PR TITLE
Pretty Print Name and Description Outside of  Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* `title` and `description` can be set from `pretty` and `description` keys at root.
+
+
 ### Changed
 
-* Moved `name` and `description` from `anyOf` to outside of schema. `anyOf` is now usable as intended for json schema.
+* Moved `title` and `description` from `anyOf` to outside of schema. `anyOf` is now usable as intended for json schema.
+
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Moved `name` and `description` from `anyOf` to outside of schema. `anyOf` is now usable as intended for json schema.
+
 ### Removed
 
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,28 @@ Options are dynamically created with the schema part of the config file.
 * When creating a schema use the following schema draft version: https://json-schema.org/draft/2020-12/schema
 * `title` are used for pretty print option names.
 * `description` is used for the options help message.
-* `anyOf` with nested `const` and `title` are a special case as a replacement for `enum` but with pretty print name.
+* For adding a description and a pretty print name to enum values (for [web-installation-instruction](https://github.com/instructions-d-installation/web-installation-instruction)):
+  1. Indent the schema with the key `schema`.
+  2. Add `pretty` and `description` keys.
+  3. Create lists like `key: Pretty Key`.
+* `title` and `description` from within the schema overwrite `pretty` and `description` outside of the schema.
+
+```yaml
+schema:
+  name: installation-instruction
+  type: object
+  properties:
+    method:
+      enum:
+        - pipx
+        - pip
+pretty:
+  pipx: Pipx
+  pip: Pip
+description:
+  pipx: Installs python packages into virtual environments.
+  pip: Standard python package manager.
+```
 
 
 ### Template

--- a/examples/pytorch/pytorch-instruction.schema.yml.jinja
+++ b/examples/pytorch/pytorch-instruction.schema.yml.jinja
@@ -1,58 +1,61 @@
-$schema: https://json-schema.org/draft/2020-12/schema
-$id: https://github.com/instructions-d-installation/installation-instruction/examples/pytorch/instruction_pytorch.schema.yml
-title: PyTorch Install Schema
-description: This is a schema which is used for constructing interactive installation instructions.
-type: object
-$comment: by Adam McKellar
-properties:
-  build:
-    title: Build
-    description: Use the latest or the tested version.
-    anyOf:
-      - title: Stable (2.3.0)
-        const: stable
-      - title: Preview (Nightly)
-        const: preview
-    default: stable
-  os:
-    title: Operating System
-    description: The operating system you use.
-    anyOf:
-      - title: Linux
-        const: linux
-      - title: Mac
-        const: mac
-      - title: Windows
-        const: win
-    default: win
-  package:
-    title: Package Manager
-    description: The package manager you use.
-    anyOf:
-      - title: Conda
-        const: conda
-      - title: Pip
-        const: pip
-    default: pip
-  compute_platform:
-    title: Compute Platform
-    description: Should your gpu or your cpu handle the task?
-    anyOf:
-      - title: CUDA 11.8
-        const: cu118
-      - title: CUDA 12.1
-        const: cu121
-      - title: ROCm 6.0
-        const: ro60
-      - title: CPU
-        const: cpu
-    default: cu118
-required:
-  - build
-  - os
-  - package
-  - compute_platform
-additionalProperties: false
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  $id: https://github.com/instructions-d-installation/installation-instruction/examples/pytorch/instruction_pytorch.schema.yml
+  title: PyTorch Install Schema
+  description: This is a schema which is used for constructing interactive installation instructions.
+  type: object
+  $comment: by Adam McKellar
+  properties:
+    build:
+      title: Build
+      description: Use the latest or the tested version.
+      enum:
+        - stable
+        - preview
+      default: stable
+    os:
+      title: Operating System
+      description: The operating system you use.
+      enum:
+        - linux
+        - mac
+        - win
+      default: win
+    package:
+      title: Package Manager
+      description: The package manager you use.
+      enum:
+        - conda
+        - pip
+      default: pip
+    compute_platform:
+      title: Compute Platform
+      description: Should your gpu or your cpu handle the task?
+      enum:
+        - cu118
+        - cu121
+        - ro60
+        - cpu
+      default: cu118
+  required:
+    - build
+    - os
+    - package
+    - compute_platform
+  additionalProperties: false
+
+pretty:
+  stable: Stable (2.3.0)
+  preview: Preview (Nightly)
+  linux: Linux
+  mac: Mac
+  win: Windows
+  conda: Conda
+  pip: Pip
+  cu118: CUDA 11.8
+  cu121: CUDA 12.1
+  ro60: ROCm 6.0
+  cpu: CPU
 
 ------
 

--- a/examples/spacy/spacy-instruction.schema.yml.jinja
+++ b/examples/spacy/spacy-instruction.schema.yml.jinja
@@ -1,93 +1,94 @@
-$schema: https://json-schema.org/draft/2020-12/schema
-$id: https://github.com/instructions-d-installation/installation-instruction/examples/spacy/schema_spacy.yml
-title: Spacy Install Schema
-description: This is a schema which is used for constructing interactive installation instructions.
-type: object
-$comment: by Kanushka Gupta
-properties:
-  os:
-    title: Operating System
-    description: Specify your Operating System
-    anyOf:
-      - title: macOs/OSX
-        const: mac
-      - title: Windows
-        const: windows
-      - title: Linux
-        const: linux
-    default: windows
-  platform:
-    title: Platform
-    description: platform
-    anyOf:
-      - title: x86
-        const: x86
-      - title: ARM/M1
-        const: arm
-    default: x86
-  package:
-    title: Package Manager
-    description: The package manager you use.
-    anyOf:
-      - title: Conda
-        const: conda
-      - title: Pip
-        const: pip
-      - title: from source
-        const: source
-    default: pip
-  hardware:
-    title: Hardware
-    description: Hardware you want to use- CPU or GPU?
-    anyOf:
-      - title: CPU
-        const: cpu
-      - title: GPU
-        const: gpu
-    type: string
-    default: cpu
-    
-  configuration:
-    title: Configuration
-    description: the configuration you have
-    anyOf:
-      - title: virtual env
-        const: venv
-      - title: train models
-        const: train_models
-  pipeline:
-    anyOf:
-      - title: efficiency
-        const: efficiency
-      - title: accuracy
-        const: accuracy
-if:
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  $id: https://github.com/instructions-d-installation/installation-instruction/examples/spacy/schema_spacy.yml
+  title: Spacy Install Schema
+  description: This is a schema which is used for constructing interactive installation instructions.
+  type: object
+  $comment: by Kanushka Gupta
   properties:
-    hardware:
-      const: gpu
-then:
-  properties:
-    cuda_runtime:
+    os:
+      title: Operating System
+      description: Specify your Operating System
       enum:
-        - CUDA 8.0
-        - CUDA 9.0
-        - CUDA 9.1
-        - CUDA 9.2
-        - CUDA 10.0
-        - CUDA 10.1
-        - CUDA 10.2
-        - CUDA 11.0
-        - CUDA 11.1
-        - CUDA 11.2 - 11.x
-        - CUDA 12.x
+        - mac
+        - windows
+        - linux
+      default: windows
+    platform:
+      title: Platform
+      description: platform
+      enum:
+        - x86
+        - arm
+      default: x86
+    package:
+      title: Package Manager
+      description: The package manager you use.
+      enum:
+        - conda
+        - pip
+        - source
+      default: pip
+    hardware:
+      title: Hardware
+      description: Hardware you want to use- CPU or GPU?
+      enum:
+        - cpu
+        - gpu
+      type: string
+      default: cpu
       
-required:
-  - os
-  - platform
-  - package
-  - hardware
-additionalProperties: false
+    configuration:
+      title: Configuration
+      description: the configuration you have
+      enum:
+        - venv
+        - train_models
+    pipeline:
+      enum:
+        - efficiency
+        - accuracy
+  if:
+    properties:
+      hardware:
+        const: gpu
+  then:
+    properties:
+      cuda_runtime:
+        enum:
+          - CUDA 8.0
+          - CUDA 9.0
+          - CUDA 9.1
+          - CUDA 9.2
+          - CUDA 10.0
+          - CUDA 10.1
+          - CUDA 10.2
+          - CUDA 11.0
+          - CUDA 11.1
+          - CUDA 11.2 - 11.x
+          - CUDA 12.x
+        
+  required:
+    - os
+    - platform
+    - package
+    - hardware
+  additionalProperties: false
 
+pretty:
+  mac: macOs/OSX
+  windows: Windows
+  linux: Linux
+  x86: x86
+  arm: ARM/M1
+  pip: Pip
+  conda: Conda
+  cpu: CPU
+  gpu: GPU
+  venv: virtual env
+  train_models: train models
+  efficiency: efficiency
+  accuracy: accuracy
 
 ------
 

--- a/installation_instruction/__main__.py
+++ b/installation_instruction/__main__.py
@@ -49,7 +49,7 @@ class ConfigReadCommand(click.MultiCommand):
 
         try:
             instruction = InstallationInstruction.from_file(config_file)
-            options = _get_flags_and_options(instruction.schema)
+            options = _get_flags_and_options(instruction.schema, getattr(instruction, "misc", None))
         except Exception as e:
             click.echo(click.style("Error (parsing options from schema): " + str(e), fg="red"))
             exit(1)

--- a/installation_instruction/get_flags_and_options_from_schema.py
+++ b/installation_instruction/get_flags_and_options_from_schema.py
@@ -42,9 +42,7 @@ def _get_flags_and_options(schema: dict) -> list[Option]:
         option_description = value.get('description', '')
         option_default = value.get('default', None)
 
-        if 'anyOf' in value:
-            option_type = Choice( [c['const'] for c in value['anyOf'] if 'const' in c] )
-        elif "enum" in value:
+        if "enum" in value:
             option_type = Choice( value["enum"] )
         else:
             option_type = SCHEMA_TO_CLICK_TYPE_MAPPING.get(option_type, click.STRING)

--- a/installation_instruction/installation_instruction.py
+++ b/installation_instruction/installation_instruction.py
@@ -81,8 +81,8 @@ class InstallationInstruction:
         for key, value in self.schema.get('properties', {}).items():
 
             result["properties"][key] = {
-                "title": value.get("title", key),
-                "description": value.get("description", ""),
+                "title": value.get("title", "") or pretty.get(key, key),
+                "description": value.get("description", "") or description.get(key, ""),
                 "type": value.get("type", "string"),
                 "default": value.get("default", None),
                 "key": key,

--- a/installation_instruction/installation_instruction.py
+++ b/installation_instruction/installation_instruction.py
@@ -75,6 +75,9 @@ class InstallationInstruction:
         result["description"] = self.schema.get("description", "")
         result["properties"] = {}
 
+        pretty = self.misc.get("pretty", {})
+        description = self.misc.get("description", {})
+
         for key, value in self.schema.get('properties', {}).items():
 
             result["properties"][key] = {
@@ -87,19 +90,10 @@ class InstallationInstruction:
             if "enum" in value:
                 result["properties"][key]["enum"] = [
                     {
-                        "title": e,
+                        "title": pretty.get(e, e),
                         "key": e,
-                        "description": "",
+                        "description": description.get(e, ""),
                     } for e in value["enum"]
-                ]
-                result["properties"][key]["type"] = "enum"
-            elif type := "anyOf" if "anyOf" in value else "oneOf" if "oneOf" in value else None:
-                result["properties"][key]["enum"] = [
-                    {
-                        "title": c.get("title", c.get("const", "")),
-                        "key": c.get("const", ""),
-                        "description": c.get("description", ""),
-                    } for c in value[type]
                 ]
                 result["properties"][key]["type"] = "enum"
                 
@@ -114,19 +108,25 @@ class InstallationInstruction:
         :raise Exception: If schema part of config is neither valid json nor valid yaml.
         :raise Exception: If no delimiter is found.
         """
-        (schema, template) = helpers._split_string_at_delimiter(config)
+        (schema_str, template) = helpers._split_string_at_delimiter(config)
         try:
-            self.schema = json.load(schema)
+            schema = json.load(schema_str)
         except:
             try:
-                self.schema = safe_load(schema)
+                schema = safe_load(schema_str)
             except:
                 raise Exception("Schema is neither a valid json nor a valid yaml.")
+            
+        if "schema" in schema:
+            self.schema = schema["schema"]
+            self.misc = {key: schema[key] for key in schema if key != "schema"}
+        else:
+            self.schema = schema
         
         try:
             Draft202012Validator.check_schema(self.schema)
-        except exceptions.SchemaError:
-            raise Exception("The given schema file is not a valid json schema.")
+        except exceptions.SchemaError as e:
+            raise Exception(f"The given schema file is not a valid json schema.\n\n{e}")
         self.template = helpers._load_template_from_string(RAISE_JINJA_MACRO_STRING+template)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def test_data_flags_options():
     with open(file_path,"r") as file:
         example = yaml.safe_load(file)
     
-    return example
+    return example["schema"]
 
 @pytest.fixture
 def test_data_flags_options_config_string_with_empty_template():

--- a/tests/data/flags_options_example.schema.yml
+++ b/tests/data/flags_options_example.schema.yml
@@ -56,3 +56,5 @@ pretty:
 
 description:
   cu121: CUDA 12.1 is the latest version of CUDA.
+  compute_platform: Not shown.
+  verbose: Activate verbose output.

--- a/tests/data/flags_options_example.schema.yml
+++ b/tests/data/flags_options_example.schema.yml
@@ -1,53 +1,58 @@
-$schema: https://json-schema.org/draft/2020-12/schema
-$id: https://github.com/instructions-d-installation/installation-instruction/examples/scikit-learn/scikit-learn-instruction.schema.yml
-title: Scikit-learn installation schema
-description: This is a Schema to construct installation instructions for the python package scikit-learn by Timo Ege.
-type: object
-properties:
-  os:
-    title: Operating System
-    description: The operating system in which the package is installed.
-    enum: 
-      - Windows
-      - macOS
-      - Linux
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  $id: https://github.com/instructions-d-installation/installation-instruction/examples/scikit-learn/scikit-learn-instruction.schema.yml
+  title: Scikit-learn installation schema
+  description: This is a Schema to construct installation instructions for the python package scikit-learn by Timo Ege.
+  type: object
+  properties:
+    os:
+      title: Operating System
+      description: The operating system in which the package is installed.
+      enum: 
+        - Windows
+        - macOS
+        - Linux
 
 
-  packager:
-    title: Packager
-    description: The package manager of your choosing.
-    enum: 
-      - pip
-      - conda
-    default: pip
+    packager:
+      title: Packager
+      description: The package manager of your choosing.
+      enum: 
+        - pip
+        - conda
+      default: pip
 
-  virtualenv:
-    title: Use pip virtualenv
-    description: Choose if you want to use a virtual environment to install the package.   
-    type: boolean 
-    default: false
+    virtualenv:
+      title: Use pip virtualenv
+      description: Choose if you want to use a virtual environment to install the package.   
+      type: boolean 
+      default: false
 
-  compute_platform:
-    title: Compute Platform
-    description: Should your gpu or your cpu handle the task?
-    anyOf:
-      - title: CUDA 11.8
-        const: cu118
-      - title: CUDA 12.1
-        const: cu121
-        description: CUDA 12.1 is the latest version of CUDA.
-    default: cu118
-  
-  verbose:
-    type: boolean
-    default: false
+    compute_platform:
+      title: Compute Platform
+      description: Should your gpu or your cpu handle the task?
+      enum:
+        - cu118
+        - cu121
+      default: cu118
+    
+    verbose:
+      type: boolean
+      default: false
 
-  requiered_flag:
-    type: boolean
+    requiered_flag:
+      type: boolean
 
-required:
-  - os
-  - packager
-  - requiered_flag
+  required:
+    - os
+    - packager
+    - requiered_flag
 
-additionalProperties: false
+  additionalProperties: false
+
+pretty:
+  cu118: CUDA 11.8
+  cu121: CUDA 12.1
+
+description:
+  cu121: CUDA 12.1 is the latest version of CUDA.

--- a/tests/data/test_install/install.cfg
+++ b/tests/data/test_install/install.cfg
@@ -1,16 +1,19 @@
-$schema: https://json-schema.org/draft/2020-12/schema
-$id: https://github.com/instructions-d-installation/installation-instruction/tests/data/test_install/install.cfg
-name: test-install
-type: object
-properties:
-  error_install:
-    type: boolean
-  error_template:
-    type: boolean
-    default: false
-required:
-  - error_install
-  - error_template
+schema:
+  $schema: https://json-schema.org/draft/2020-12/schema
+  $id: https://github.com/instructions-d-installation/installation-instruction/tests/data/test_install/install.cfg
+  name: test-install
+  type: object
+  properties:
+    error_install:
+      type: boolean
+    error_template:
+      type: boolean
+      default: false
+  required:
+    - error_install
+    - error_template
+description:
+  error_install: Test for flag without default value.
 ------
 echo "start" &&
 {%- if error_install %}

--- a/tests/test_get_flags_and_options_from_schema.py
+++ b/tests/test_get_flags_and_options_from_schema.py
@@ -17,7 +17,7 @@ from installation_instruction.get_flags_and_options_from_schema import _get_flag
 
 def test_get_flags_and_options(test_data_flags_options):
     example_schema = test_data_flags_options
-    options = _get_flags_and_options(example_schema)
+    options = _get_flags_and_options(example_schema, {"description": { "verbose": "Activate verbose output." }})
 
     assert len(options) == 6
 
@@ -42,6 +42,7 @@ def test_get_flags_and_options(test_data_flags_options):
     assert options[3].default == "cu118"
 
     assert options[4].opts == ["--verbose"]
+    assert options[4].help == "Activate verbose output."
     assert options[4].required == False
     assert options[4].default == False
 

--- a/tests/test_installation_instruction.py
+++ b/tests/test_installation_instruction.py
@@ -71,3 +71,5 @@ def test_parse_schema(test_data_flags_options_config_string_with_empty_template)
         "type": "boolean",
         "key": "virtualenv"
     }
+
+    assert schema["properties"]["verbose"]["description"] == "Activate verbose output."


### PR DESCRIPTION
Removes necessity of abusing `anyOf` for `enum` with pretty print names and descriptions by moving those fields outside the schema.