### PR TITLE
Cat Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Added `cat` command: Users can now see the source of an `install.cfg` file with `ibi cat`.
+
+
+### Changed
+
+* Switched to sandboxed rendering of template for security purposes.
+
+
 ## [0.4.0] - 2024-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Options:
   -h, --help  Show this message and exit.
 
 Commands:
+  cat      Shows source of installation instructions config file.
   install  Installs with config and parameters given.
   show     Shows installation instructions for your specified config file...
 ```
@@ -91,7 +92,6 @@ Options are dynamically created with the schema part of the config file.
   2. Add `pretty` and `description` keys.
   3. Create lists like `key: Pretty Key`.
 * `title` and `description` from within the schema overwrite `pretty` and `description` outside of the schema.
-* For the package to set the default os to the running system, name the property `__os__`.
 
 ```yaml
 schema:
@@ -108,6 +108,15 @@ pretty:
 description:
   pipx: Installs python packages into virtual environments.
   pip: Standard python package manager.
+```
+
+* For the package to set the default os to the running system, name the property `__os__`.
+
+```yaml
+__os__:
+  - windows
+  - linux
+  - macos
 ```
 
 

--- a/installation_instruction/__main__.py
+++ b/installation_instruction/__main__.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 
 from sys import exit
-from os.path import isfile, isdir
 from subprocess import run
 import platform
 
 import click
-from yaml import safe_dump
 
 from .__init__ import __version__, __description__, __repository__, __author__, __author_email__, __license__
 from .get_flags_and_options_from_schema import _get_flags_and_options

--- a/installation_instruction/installation_instruction.py
+++ b/installation_instruction/installation_instruction.py
@@ -16,7 +16,6 @@
 from yaml import safe_load
 import json
 from jsonschema import validate, Draft202012Validator, exceptions
-from jinja2 import Environment, Template
 from jinja2.exceptions import UndefinedError
 
 import installation_instruction.helpers as helpers


### PR DESCRIPTION
This pull request adds the `cat` command. This command enables the end user to see the source of the schema/template with `ibi cat <path>`. 
Also the template is rendered in a sandboxed environment now.